### PR TITLE
Add form for chatbot configuration

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,4 @@
-site-factice {
+.site-factice {
   font-family: 'Segoe UI', sans-serif;
   max-width: 800px;
   margin: auto;
@@ -38,4 +38,29 @@ footer {
   text-align: center;
   font-size: 0.9em;
   color: #888;
+}
+
+.config-form {
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid #ddd;
+}
+
+.config-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.config-form input,
+.config-form textarea {
+  padding: 6px;
+  font-size: 1em;
+}
+
+.generated-script {
+  background: #f5f5f5;
+  padding: 10px;
+  margin-top: 10px;
+  overflow: auto;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import "./App.css";
+import ConfigForm from "./ConfigForm";
 
 function App() {
   useEffect(() => {
@@ -47,6 +48,8 @@ function App() {
       <footer>
         <p>© 2025 NovaCorp - Tous droits factices réservés.</p>
       </footer>
+
+      <ConfigForm />
     </div>
   );
 }

--- a/src/ConfigForm.js
+++ b/src/ConfigForm.js
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+
+const BACKEND_URL = "https://chatbot-vocal-backend.onrender.com";
+const WIDGET_URL = "https://chatbot-vocal-frontend.onrender.com/ChatbotWidget.js";
+
+function ConfigForm() {
+  const [clientId, setClientId] = useState('');
+  const [color, setColor] = useState('#0078d4');
+  const [logoUrl, setLogoUrl] = useState('');
+  const [suggestions, setSuggestions] = useState('');
+  const [rgpdLink, setRgpdLink] = useState('');
+  const [resultScript, setResultScript] = useState('');
+  const [status, setStatus] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      clientId,
+      color,
+      logo: logoUrl,
+      suggestions: suggestions
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean),
+      rgpdLink,
+    };
+    try {
+      await fetch(`${BACKEND_URL}/api/create-config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      setStatus('Configuration enregistr\u00e9e !');
+      setResultScript(
+        `<script src="${WIDGET_URL}" data-client-id="${clientId}" data-backend-url="${BACKEND_URL}"></script>`
+      );
+    } catch (err) {
+      console.error(err);
+      setStatus("Erreur lors de l'enregistrement");
+    }
+  };
+
+  return (
+    <div className="config-form">
+      <h2>Configurer mon chatbot</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          ID client
+          <input value={clientId} onChange={(e) => setClientId(e.target.value)} required />
+        </label>
+        <label>
+          Couleur principale
+          <input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+        </label>
+        <label>
+          URL du logo
+          <input value={logoUrl} onChange={(e) => setLogoUrl(e.target.value)} />
+        </label>
+        <label>
+          Suggestions (une par ligne)
+          <textarea value={suggestions} onChange={(e) => setSuggestions(e.target.value)} />
+        </label>
+        <label>
+          Lien vers la politique RGPD
+          <input value={rgpdLink} onChange={(e) => setRgpdLink(e.target.value)} />
+        </label>
+        <button type="submit">Cr\u00e9er la configuration</button>
+      </form>
+      {status && <p>{status}</p>}
+      {resultScript && (
+        <pre className="generated-script"><code>{resultScript}</code></pre>
+      )}
+    </div>
+  );
+}
+
+export default ConfigForm;


### PR DESCRIPTION
## Summary
- load ConfigForm component and include it in the main page
- style the new form and fix `.site-factice` class selector
- implement ConfigForm for collecting client options and generating the embed script

## Testing
- `npm install`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684192de50208326b27fa0c5f055ef78