### PR TITLE
Fix missing closing brace in ChatbotWidget

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -766,5 +766,5 @@ function initChatbot(config, backendUrl, clientId) {
     .msg-fadein { animation: fadeInUp 0.4s; }
     @keyframes fadeInUp { from { opacity:0; transform:translateY(12px);} to{opacity:1; transform:translateY(0);} }
   `;
-      shadow.appendChild(style);
-})(); // <-- C'est tout sur la même séquence, pas de parenthèse seule.
+  shadow.appendChild(style);
+}


### PR DESCRIPTION
## Summary
- close `initChatbot` function in `ChatbotWidget.js`

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6842b3b91040832697736ec6a86c7a27