### PR TITLE
Add input keydown handling for Enter

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -407,6 +407,13 @@ function initChatbot(config, backendUrl, clientId) {
     minHeight: '44px'
   });
 
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && input.value.trim()) {
+      handleMessage(input.value);
+      input.value = '';
+    }
+  });
+
   const sendBtn = document.createElement('button');
   sendBtn.textContent = '➤';
   Object.assign(sendBtn.style, {
@@ -567,10 +574,6 @@ function initChatbot(config, backendUrl, clientId) {
   document.addEventListener('keydown', (e) => {
     if (e.key === "Escape" && isWidgetOpen) {
       closeWidget();
-    }
-    if (e.key === "Enter" && isTextMode && document.activeElement === input && input.value.trim()) {
-      handleMessage(input.value);
-      input.value = '';
     }
   });
 

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -407,6 +407,13 @@ function initChatbot(config, backendUrl, clientId) {
     minHeight: '44px'
   });
 
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && input.value.trim()) {
+      handleMessage(input.value);
+      input.value = '';
+    }
+  });
+
   const sendBtn = document.createElement('button');
   sendBtn.textContent = '➤';
   Object.assign(sendBtn.style, {
@@ -567,10 +574,6 @@ function initChatbot(config, backendUrl, clientId) {
   document.addEventListener('keydown', (e) => {
     if (e.key === "Escape" && isWidgetOpen) {
       closeWidget();
-    }
-    if (e.key === "Enter" && isTextMode && document.activeElement === input && input.value.trim()) {
-      handleMessage(input.value);
-      input.value = '';
     }
   });
 


### PR DESCRIPTION
## Summary
- handle Enter key events directly on the input in ChatbotWidget
- preserve Escape shortcut on document level

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e2a5f0088326809be5ee428d71ca