### PR TITLE
Disable swipe to close on mobile

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -718,18 +718,7 @@ function initChatbot(config, backendUrl, clientId) {
       });
   }
 
-  // ============ PATCH SWIPE DOWN TO CLOSE (UX mobile) ===========
-  let touchStartY = null;
-  widget.addEventListener('touchstart', e => {
-    if (e.touches.length === 1) touchStartY = e.touches[0].clientY;
-  });
-  widget.addEventListener('touchmove', e => {
-    if (touchStartY !== null && e.touches.length === 1) {
-      const dy = e.touches[0].clientY - touchStartY;
-      if (dy > 60) { closeWidget(); touchStartY = null; }
-    }
-  });
-  widget.addEventListener('touchend', () => { touchStartY = null; });
+
 
   // PATCH DIEGO : widget TOUJOURS fermé au démarrage, même si historique
   closeWidget();

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -718,18 +718,7 @@ function initChatbot(config, backendUrl, clientId) {
       });
   }
 
-  // ============ PATCH SWIPE DOWN TO CLOSE (UX mobile) ===========
-  let touchStartY = null;
-  widget.addEventListener('touchstart', e => {
-    if (e.touches.length === 1) touchStartY = e.touches[0].clientY;
-  });
-  widget.addEventListener('touchmove', e => {
-    if (touchStartY !== null && e.touches.length === 1) {
-      const dy = e.touches[0].clientY - touchStartY;
-      if (dy > 60) { closeWidget(); touchStartY = null; }
-    }
-  });
-  widget.addEventListener('touchend', () => { touchStartY = null; });
+
 
   // PATCH DIEGO : widget TOUJOURS fermé au démarrage, même si historique
   closeWidget();


### PR DESCRIPTION
## Summary
- remove swipe-down event handlers from widget to prevent accidental closure

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_6842e35ae57c8326b49c4a956b762116