### PR TITLE
Fix widget version import mismatch

### DIFF
--- a/src/ConfigForm.js
+++ b/src/ConfigForm.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';        // 1er import
-import { VERSION_WIDGET } from './widgetVersion';   // 2ème import
+import { WIDGET_VERSION } from './widgetVersion';   // 2ème import
 
 const URL_BACKEND = "https://chatbot-vocal-backend.onrender.com";
-const URL_WIDGET = `https://chatbot-vocal-frontend.onrender.com/ChatbotWidget.js?v=${VERSION_WIDGET}`;
+const URL_WIDGET = `https://chatbot-vocal-frontend.onrender.com/ChatbotWidget.js?v=${WIDGET_VERSION}`;
 
 function ConfigForm() {
   const [clientId, setClientId] = useState('');
@@ -26,7 +26,7 @@ function ConfigForm() {
       rgpdLink,
     };
     try {
-      await fetch(`${BACKEND_URL}/api/create-config`, {
+      await fetch(`${URL_BACKEND}/api/create-config`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/src/widgetVersion.js
+++ b/src/widgetVersion.js
@@ -1,1 +1,1 @@
-export const VERSION_WIDGET = '1.0.4';
+export const WIDGET_VERSION = '1.0.4';


### PR DESCRIPTION
## Summary
- use `WIDGET_VERSION` constant consistently
- fix backend URL variable name in ConfigForm

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_684357ce1ce88326bdda8f8044a0e7b5