### PR TITLE
Style reply links as buttons

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -627,6 +627,15 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
         ALLOWED_TAGS: ['b', 'i', 'strong', 'a', 'img', 'br', 'ul', 'li', 'p'],
         ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'target']
       });
+      div.querySelectorAll('a').forEach(a => {
+        a.style.background = config.color;
+        a.style.color = '#fff';
+        a.style.padding = '6px 10px';
+        a.style.borderRadius = '8px';
+        a.style.display = 'inline-block';
+        a.style.textDecoration = 'none';
+        a.style.marginTop = '4px';
+      });
     } else {
       div.textContent = msg;
     }
@@ -762,9 +771,14 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     }
     .custom-chatbot-widget img { max-width: 100%; border-radius: 10px; margin-top: 6px; display: block; }
     .custom-chatbot-widget a {
-      color: ${config.color};
-      text-decoration: underline;
+      display: inline-block;
+      background: ${config.color};
+      color: #fff;
+      padding: 6px 10px;
+      border-radius: 8px;
+      text-decoration: none;
       font-size: 0.95em;
+      margin-top: 4px;
     }
     .chatbot-loader-bubbles {
       display: flex; align-items: center; height: 22px;


### PR DESCRIPTION
## Summary
- add styling for markdown links as action buttons in `appendMessage`
- update CSS so links render as buttons

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68436f3075788326987ba5ba847ceeca