### PR TITLE
Style links in widget

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -627,6 +627,14 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
         ALLOWED_TAGS: ['b', 'i', 'strong', 'a', 'img', 'br', 'ul', 'li', 'p'],
         ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'target']
       });
+      div.querySelectorAll('a').forEach(a => {
+        a.style.background = config.color;
+        a.style.color = '#fff';
+        a.style.padding = '6px 10px';
+        a.style.borderRadius = '8px';
+        a.style.textDecoration = 'none';
+        a.style.display = 'inline-block';
+      });
     } else {
       div.textContent = msg;
     }
@@ -762,9 +770,13 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     }
     .custom-chatbot-widget img { max-width: 100%; border-radius: 10px; margin-top: 6px; display: block; }
     .custom-chatbot-widget a {
-      color: ${config.color};
-      text-decoration: underline;
+      color: #fff;
+      background: ${config.color};
+      text-decoration: none;
+      padding: 6px 10px;
+      border-radius: 8px;
       font-size: 0.95em;
+      display: inline-block;
     }
     .chatbot-loader-bubbles {
       display: flex; align-items: center; height: 22px;

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -627,6 +627,14 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
         ALLOWED_TAGS: ['b', 'i', 'strong', 'a', 'img', 'br', 'ul', 'li', 'p'],
         ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'target']
       });
+      div.querySelectorAll('a').forEach(a => {
+        a.style.background = config.color;
+        a.style.color = '#fff';
+        a.style.padding = '6px 10px';
+        a.style.borderRadius = '8px';
+        a.style.textDecoration = 'none';
+        a.style.display = 'inline-block';
+      });
     } else {
       div.textContent = msg;
     }
@@ -762,9 +770,13 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     }
     .custom-chatbot-widget img { max-width: 100%; border-radius: 10px; margin-top: 6px; display: block; }
     .custom-chatbot-widget a {
-      color: ${config.color};
-      text-decoration: underline;
+      color: #fff;
+      background: ${config.color};
+      text-decoration: none;
+      padding: 6px 10px;
+      border-radius: 8px;
       font-size: 0.95em;
+      display: inline-block;
     }
     .chatbot-loader-bubbles {
       display: flex; align-items: center; height: 22px;


### PR DESCRIPTION
## Summary
- style sanitized bot links in JS so they look like buttons
- update widget CSS so `<a>` elements have button visuals

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684370741dcc83268bd58c1ff96585f7