### PR TITLE
Add speech summary parsing

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -192,9 +192,27 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     return tmp.textContent || tmp.innerText || '';
   }
 
+  function buildSpeechSummary(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    tmp.querySelectorAll('a, img').forEach(el => el.remove());
+    const text = (tmp.textContent || tmp.innerText || '').trim();
+    const priceMatch = text.match(/\d+[.,]?\d*\s*€+/);
+    const price = priceMatch ? priceMatch[0].trim() : null;
+    const nameEl = tmp.querySelector('[data-product-name], .product-name, h1, h2, h3, strong, b');
+    let name = nameEl ? nameEl.textContent.trim() : null;
+    if (!name && priceMatch) {
+      name = text.slice(0, priceMatch.index).trim();
+    }
+    if (name && price) {
+      return `Je vous recommande ${name} au prix de ${price}.`;
+    }
+    return text;
+  }
+
   function speakText(html) {
     if (!window.speechSynthesis) return;
-    const text = sanitizeForSpeech(html);
+    const text = buildSpeechSummary(html);
     const utterance = new SpeechSynthesisUtterance(text);
     window.speechSynthesis.speak(utterance);
   }

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -192,9 +192,27 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     return tmp.textContent || tmp.innerText || '';
   }
 
+  function buildSpeechSummary(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    tmp.querySelectorAll('a, img').forEach(el => el.remove());
+    const text = (tmp.textContent || tmp.innerText || '').trim();
+    const priceMatch = text.match(/\d+[.,]?\d*\s*€+/);
+    const price = priceMatch ? priceMatch[0].trim() : null;
+    const nameEl = tmp.querySelector('[data-product-name], .product-name, h1, h2, h3, strong, b');
+    let name = nameEl ? nameEl.textContent.trim() : null;
+    if (!name && priceMatch) {
+      name = text.slice(0, priceMatch.index).trim();
+    }
+    if (name && price) {
+      return `Je vous recommande ${name} au prix de ${price}.`;
+    }
+    return text;
+  }
+
   function speakText(html) {
     if (!window.speechSynthesis) return;
-    const text = sanitizeForSpeech(html);
+    const text = buildSpeechSummary(html);
     const utterance = new SpeechSynthesisUtterance(text);
     window.speechSynthesis.speak(utterance);
   }


### PR DESCRIPTION
## Summary
- parse product name and price from bot HTML
- build short summary for speech synthesis
- use summary when speaking

## Testing
- `npm install`
- `CI=true npm test -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_6843707db0dc8326b7358fd63163787a