### PR TITLE
Add DOM markdown and sanitization tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "concurrently": "^9.1.2"
+        "concurrently": "^9.1.2",
+        "dompurify": "^3.2.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6839,6 +6840,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     ]
   },
   "devDependencies": {
-    "concurrently": "^9.1.2"
+    "concurrently": "^9.1.2",
+    "dompurify": "^3.2.6"
   }
 }

--- a/src/__tests__/markdownRendering.test.js
+++ b/src/__tests__/markdownRendering.test.js
@@ -1,0 +1,43 @@
+import { marked } from 'marked';
+import createDOMPurify from 'dompurify';
+
+const DOMPurify = createDOMPurify(window);
+
+function renderMarkdownMessage(md) {
+  const container = document.createElement('div');
+  const html = DOMPurify.sanitize(marked.parse(md), {
+    ALLOWED_TAGS: ['b', 'i', 'strong', 'a', 'img', 'br', 'ul', 'li', 'p'],
+    ALLOWED_ATTR: ['href', 'src', 'alt', 'title', 'target'],
+  });
+  container.innerHTML = html;
+  return container;
+}
+
+test('bot markdown renders image and link elements', () => {
+  const md = '![alt](http://example.com/img.png)\\n\\n[Example](http://example.com)';
+  const el = renderMarkdownMessage(md);
+  expect(el.querySelector('img')).not.toBeNull();
+  const link = el.querySelector('a');
+  expect(link).not.toBeNull();
+  expect(link.textContent).toBe('Example');
+});
+
+test('link receives styling from CSS', () => {
+  const style = document.createElement('style');
+  style.textContent = '.custom-chatbot-widget a { color: rgb(1, 2, 3); }';
+  document.head.appendChild(style);
+
+  const md = '[Link](http://example.com)';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'custom-chatbot-widget';
+  const el = renderMarkdownMessage(md);
+  wrapper.appendChild(el);
+  document.body.appendChild(wrapper);
+
+  const link = wrapper.querySelector('a');
+  const color = getComputedStyle(link).color;
+  expect(color).toBe('rgb(1, 2, 3)');
+
+  document.head.removeChild(style);
+  document.body.removeChild(wrapper);
+});

--- a/src/__tests__/sanitizeForSpeech.test.js
+++ b/src/__tests__/sanitizeForSpeech.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+// Tests for sanitizeForSpeech function extracted from ChatbotWidget
+
+function sanitizeForSpeech(html) {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  tmp.querySelectorAll('a').forEach(a => {
+    const text = document.createTextNode(a.textContent);
+    a.parentNode.replaceChild(text, a);
+  });
+  tmp.querySelectorAll('img').forEach(img => img.remove());
+  const raw = tmp.textContent || tmp.innerText || '';
+  return raw.replace(/\s+/g, ' ').trim();
+}
+
+test('keeps link text and removes URLs/images', () => {
+  const html = '<p>Go to <a href="https://example.com">Example</a> <img src="pic.png" alt="pic"> now</p>';
+  expect(sanitizeForSpeech(html)).toBe('Go to Example now');
+});


### PR DESCRIPTION
## Summary
- install `dompurify` for unit tests
- add `sanitizeForSpeech` test
- add tests for markdown rendering

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684370861c608326906a1fce4427debf