### PR TITLE
Add HTML-to-Markdown conversion utility

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -221,6 +221,14 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     window.speechSynthesis.speak(utterance);
   }
 
+  function htmlToMarkdown(html) {
+    if (window.TurndownService) {
+      const t = new window.TurndownService();
+      return t.turndown(html);
+    }
+    return html;
+  }
+
   // --- GESTION DE L'HISTORIQUE & DE L'OUVERTURE CHAT ---
   let chatHistory = [];
   try {
@@ -703,8 +711,12 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
       .then(r => r.json())
       .then(data => {
         hideLoader();
-        const msgEl = appendMessage(data.text || '(Pas de réponse)', 'bot', true);
-        chatHistory.push({ msg: data.text || '(Pas de réponse)', sender: 'bot', isHTML: true });
+        let text = data.text || '(Pas de réponse)';
+        if (/<[a-z][\s\S]*>/i.test(text)) {
+          text = htmlToMarkdown(text);
+        }
+        const msgEl = appendMessage(text, 'bot', true);
+        chatHistory.push({ msg: text, sender: 'bot', isHTML: true });
         localStorage.setItem('chatbotChatHistory', JSON.stringify(chatHistory));
         if (!isTextMode) {
           if (data.audioUrl) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "react-scripts": "^5.0.1",
+        "turndown": "^7.1.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -7003,6 +7004,12 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/dompurify": {
       "version": "3.2.6",
@@ -17373,6 +17380,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.2.tgz",
+      "integrity": "sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "domino": "^2.1.6"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-scripts": "^5.0.1",
+    "turndown": "^7.1.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -221,6 +221,14 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     window.speechSynthesis.speak(utterance);
   }
 
+  function htmlToMarkdown(html) {
+    if (window.TurndownService) {
+      const t = new window.TurndownService();
+      return t.turndown(html);
+    }
+    return html;
+  }
+
   // --- GESTION DE L'HISTORIQUE & DE L'OUVERTURE CHAT ---
   let chatHistory = [];
   try {
@@ -694,8 +702,12 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
       .then(r => r.json())
       .then(data => {
         hideLoader();
-        const msgEl = appendMessage(data.text || '(Pas de réponse)', 'bot', true);
-        chatHistory.push({ msg: data.text || '(Pas de réponse)', sender: 'bot', isHTML: true });
+        let text = data.text || '(Pas de réponse)';
+        if (/<[a-z][\s\S]*>/i.test(text)) {
+          text = htmlToMarkdown(text);
+        }
+        const msgEl = appendMessage(text, 'bot', true);
+        chatHistory.push({ msg: text, sender: 'bot', isHTML: true });
         localStorage.setItem('chatbotChatHistory', JSON.stringify(chatHistory));
         if (!isTextMode) {
           if (data.audioUrl) {

--- a/src/__tests__/htmlToMarkdown.test.js
+++ b/src/__tests__/htmlToMarkdown.test.js
@@ -1,0 +1,7 @@
+import htmlToMarkdown from '../htmlToMarkdown';
+
+test('converts HTML links to markdown', () => {
+  const html = '<p>Go to <a href="https://example.com">Example</a></p>';
+  const md = htmlToMarkdown(html).trim();
+  expect(md).toBe('Go to [Example](https://example.com)');
+});

--- a/src/htmlToMarkdown.js
+++ b/src/htmlToMarkdown.js
@@ -1,0 +1,7 @@
+import TurndownService from 'turndown';
+
+const turndownService = new TurndownService();
+
+export default function htmlToMarkdown(html) {
+  return turndownService.turndown(html);
+}


### PR DESCRIPTION
## Summary
- add Turndown dependency
- create `htmlToMarkdown` helper
- hook helper into ChatbotWidget to convert HTML responses
- test HTML→Markdown conversion

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843897775c48326beae39e9b042f0cc