### PR TITLE
Fix CTA display when chat unopened

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -515,7 +515,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   widget.appendChild(inputBox);
 
   vocalCtaBox = document.createElement('div');
-  vocalCtaBox.style.display = hasOpenedChat ? 'none' : 'none';
+  vocalCtaBox.style.display = hasOpenedChat ? 'none' : 'flex';
   vocalCtaBox.style.justifyContent = 'center';
   vocalCtaBox.style.alignItems = 'center';
   vocalCtaBox.style.margin = '12px 0 0 0';

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -460,7 +460,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   widget.appendChild(inputBox);
 
   vocalCtaBox = document.createElement('div');
-  vocalCtaBox.style.display = hasOpenedChat ? 'none' : 'none';
+  vocalCtaBox.style.display = hasOpenedChat ? 'none' : 'flex';
   vocalCtaBox.style.justifyContent = 'center';
   vocalCtaBox.style.alignItems = 'center';
   vocalCtaBox.style.margin = '12px 0 0 0';


### PR DESCRIPTION
## Summary
- show the vocal CTA button when the chat hasn't opened yet

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aee288f4832687097e4c44b1f589