### PR TITLE
Add ChatBox component tied to widget history

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -253,6 +253,11 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   try {
     chatHistory = JSON.parse(localStorage.getItem('chatbotChatHistory') || '[]');
   } catch (e) {}
+  function notifyHistory() {
+    window.chatHistory = chatHistory.slice();
+    window.dispatchEvent(new Event('chatHistoryUpdate'));
+  }
+  notifyHistory();
   let hasOpenedChat = false;
   try {
     hasOpenedChat = !!JSON.parse(localStorage.getItem('chatbotHasOpened') || 'false');
@@ -612,6 +617,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     if (vocalCtaBox) vocalCtaBox.style.display = 'none';
     if (suggBox) suggBox.style.display = '';
     closeWidget();
+    notifyHistory();
   };
   rgpd.parentNode.insertBefore(clearHistory, rgpd.nextSibling);
 
@@ -746,6 +752,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     appendMessage(msg, 'user');
     chatHistory.push({ msg, sender: 'user', isHTML: false });
     localStorage.setItem('chatbotChatHistory', JSON.stringify(chatHistory));
+    notifyHistory();
     showLoader();
     if (currentAudio && !currentAudio.paused) {
       currentAudio.pause();
@@ -767,6 +774,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
         const msgEl = appendMessage(text, 'bot', true);
         chatHistory.push({ msg: text, sender: 'bot', isHTML: true });
         localStorage.setItem('chatbotChatHistory', JSON.stringify(chatHistory));
+        notifyHistory();
         if (!isTextMode) {
           if (data.audioUrl) {
             currentAudio = new Audio(data.audioUrl);
@@ -791,6 +799,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
             appendMessage("(Réponse vocale indisponible pour ce message)", 'bot');
             chatHistory.push({ msg: "(Réponse vocale indisponible pour ce message)", sender: 'bot', isHTML: false });
             localStorage.setItem('chatbotChatHistory', JSON.stringify(chatHistory));
+            notifyHistory();
             speakText(data.text || '');
           }
         }
@@ -800,6 +809,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
         appendMessage("Désolé, le serveur est injoignable.", 'bot');
         chatHistory.push({ msg: "Désolé, le serveur est injoignable.", sender: 'bot', isHTML: false });
         localStorage.setItem('chatbotChatHistory', JSON.stringify(chatHistory));
+        notifyHistory();
         showAlert("Erreur : le backend du chatbot n'est pas joignable.");
       });
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import "./App.css";
 import ConfigForm from "./ConfigForm";
+import ChatBox from "./ChatBox";
 import { WIDGET_VERSION } from "./widgetVersion";
 
 function App() {
@@ -9,7 +10,7 @@ function App() {
     const CLIENT_ID = "novacorp"; // ← L'ID pour charger config/novacorp.json
     const BACKEND_URL = "https://chatbot-vocal-backend.onrender.com";
     const FRONTEND_WIDGET_URL = `https://chatbot-vocal-frontend.onrender.com/ChatbotWidget.js?v=${WIDGET_VERSION}`;
-    
+
     // Injecte dynamiquement le widget chatbot vocal
     const script = document.createElement('script');
     script.src = FRONTEND_WIDGET_URL;
@@ -38,6 +39,7 @@ function App() {
         </ul>
       </section>
       <ConfigForm />
+      <ChatBox />
 
       <section>
         <h2>Qui sommes-nous ?</h2>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
+jest.mock('react-markdown', () => {
+  const React = require('react');
+  return ({ children }) => React.createElement('div', {}, children);
+});
+
 test('renders NovaCorp header', () => {
   render(<App />);
   const headerElement = screen.getByRole('heading', { name: /NovaCorp/i });

--- a/src/ChatBox.js
+++ b/src/ChatBox.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import './ChatMessage.css';
+
+function ChatBox() {
+  const [expanded, setExpanded] = useState(false);
+  const [messages, setMessages] = useState(() => window.chatHistory || []);
+
+  useEffect(() => {
+    function handleUpdate() {
+      setMessages([...window.chatHistory]);
+    }
+    window.addEventListener('chatHistoryUpdate', handleUpdate);
+    return () => window.removeEventListener('chatHistoryUpdate', handleUpdate);
+  }, []);
+
+  return (
+    <div
+      className={`relative bg-white rounded-lg p-3 overflow-y-auto transition-all ${expanded ? 'max-h-[75vh]' : 'max-h-40'}`}
+    >
+      <button
+        className="absolute top-1 right-1 text-xl"
+        onClick={() => setExpanded(!expanded)}
+        aria-label={expanded ? 'Réduire' : 'Agrandir'}
+      >
+        {expanded ? '🗕' : '🗖'}
+      </button>
+      {messages.map((m, idx) => (
+        <div key={idx} className={`flex my-2 ${m.sender === 'user' ? 'justify-end' : ''}`}> 
+          <div className={`${m.sender === 'user' ? 'bg-blue-100' : 'bg-gray-100'} rounded-xl p-2 max-w-[85%]`}>
+            <ReactMarkdown>{m.msg}</ReactMarkdown>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default ChatBox;


### PR DESCRIPTION
## Summary
- create `ChatBox` component using ReactMarkdown and Tailwind classes
- wire widget's `chatHistory` to a global store and notify React via `chatHistoryUpdate`
- show `ChatBox` in `App`
- mock ReactMarkdown in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849c21b067483268dd5ffc36bf81ce7