### PR TITLE
Integrate expandable ChatBox component

### DIFF
--- a/src/ChatBox.js
+++ b/src/ChatBox.js
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import './ChatMessage.css';
+import React, { useEffect, useState } from "react";
+import ReactMarkdown from "react-markdown";
 
-function ChatBox() {
+export default function ChatBox() {
   const [expanded, setExpanded] = useState(false);
   const [messages, setMessages] = useState(() => window.chatHistory || []);
 
@@ -10,30 +9,45 @@ function ChatBox() {
     function handleUpdate() {
       setMessages([...window.chatHistory]);
     }
-    window.addEventListener('chatHistoryUpdate', handleUpdate);
-    return () => window.removeEventListener('chatHistoryUpdate', handleUpdate);
+    window.addEventListener("chatHistoryUpdate", handleUpdate);
+    return () => window.removeEventListener("chatHistoryUpdate", handleUpdate);
   }, []);
 
   return (
-    <div
-      className={`relative bg-white rounded-lg p-3 overflow-y-auto transition-all ${expanded ? 'max-h-[75vh]' : 'max-h-40'}`}
-    >
-      <button
-        className="absolute top-1 right-1 text-xl"
-        onClick={() => setExpanded(!expanded)}
-        aria-label={expanded ? 'Réduire' : 'Agrandir'}
+    <div className="flex flex-col w-full items-center">
+      <div
+        className={`relative transition-all duration-300 bg-white rounded-2xl shadow p-4 mb-2 w-full max-w-lg ${
+          expanded ? "max-h-[80vh]" : "max-h-72"
+        } overflow-y-auto`}
+        style={{ minHeight: 120 }}
       >
-        {expanded ? '🗕' : '🗖'}
-      </button>
-      {messages.map((m, idx) => (
-        <div key={idx} className={`flex my-2 ${m.sender === 'user' ? 'justify-end' : ''}`}> 
-          <div className={`${m.sender === 'user' ? 'bg-blue-100' : 'bg-gray-100'} rounded-xl p-2 max-w-[85%]`}>
-            <ReactMarkdown>{m.msg}</ReactMarkdown>
+        {/* Bouton en haut à droite */}
+        <button
+          onClick={() => setExpanded((e) => !e)}
+          className="absolute top-3 right-4 bg-gray-100 hover:bg-gray-200 transition px-3 py-1 rounded-xl text-xs shadow font-medium z-10"
+        >
+          {expanded ? "Réduire" : "Agrandir"}
+        </button>
+
+        {/* Contenu du chat */}
+        {messages.map((msg, idx) => (
+          <div key={idx} className="mb-2">
+            <ReactMarkdown
+              components={{
+                img: ({ node, ...props }) => (
+                  <img
+                    {...props}
+                    className="my-2 rounded-xl mx-auto max-h-72 object-contain"
+                    alt={props.alt}
+                  />
+                ),
+              }}
+            >
+              {msg.content || msg.msg}
+            </ReactMarkdown>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   );
 }
-
-export default ChatBox;

--- a/src/__tests__/ChatBox.test.js
+++ b/src/__tests__/ChatBox.test.js
@@ -1,15 +1,14 @@
-import React, {useState} from 'react';
-import {render, fireEvent} from '@testing-library/react';
-import ChatMessage from '../ChatMessage';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import ChatBox from '../ChatBox';
 
 jest.mock('react-markdown', () => {
   const React = require('react');
   const { marked } = require('marked/lib/marked.cjs');
   const createDOMPurify = require('dompurify');
   const DOMPurify = createDOMPurify(globalThis.window);
-  return ({ children, markdown }) => {
-    const md = markdown || children;
-    const html = DOMPurify.sanitize(marked.parse(md), {
+  return ({ children }) => {
+    const html = DOMPurify.sanitize(marked.parse(children), {
       ALLOWED_TAGS: ['b','i','strong','a','img','br','ul','li','p','h1','h2','h3','h4','h5','h6','em','ol','blockquote'],
       ALLOWED_ATTR: ['href','src','alt','title','target']
     });
@@ -17,36 +16,28 @@ jest.mock('react-markdown', () => {
   };
 });
 
-function ChatBox({markdown}) {
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <div>
-      <button data-testid="toggle" onClick={() => setExpanded(e=>!e)}>
-        {expanded ? 'Reduce' : 'Expand'}
-      </button>
-      <div data-testid="chat-log" className={expanded ? 'expanded' : 'collapsed'}>
-        <ChatMessage markdown={markdown} />
-      </div>
-    </div>
-  );
-}
+describe('ChatBox', () => {
+  beforeEach(() => {
+    window.chatHistory = [{ msg: 'Hello' }];
+  });
 
-test('expand/collapse button toggles height classes', () => {
-  const {getByTestId} = render(<ChatBox markdown="Hello" />);
-  const toggle = getByTestId('toggle');
-  const chatLog = getByTestId('chat-log');
-  expect(chatLog.className).toContain('collapsed');
-  fireEvent.click(toggle);
-  expect(chatLog.className).toContain('expanded');
-  fireEvent.click(toggle);
-  expect(chatLog.className).toContain('collapsed');
-});
+  test('expand/collapse button toggles height classes', () => {
+    const { getByRole, container } = render(<ChatBox />);
+    const btn = getByRole('button');
+    const box = container.querySelector('div.relative');
+    expect(box.className).toContain('max-h-72');
+    fireEvent.click(btn);
+    expect(box.className).toContain('max-h-[80vh]');
+    fireEvent.click(btn);
+    expect(box.className).toContain('max-h-72');
+  });
 
-test('images render correctly when expanded', () => {
-  const md = '![alt](http://example.com/img.png)';
-  const {getByTestId} = render(<ChatBox markdown={md} />);
-  fireEvent.click(getByTestId('toggle'));
-  const img = getByTestId('chat-log').querySelector('img');
-  expect(img).toBeInTheDocument();
-  expect(img.src).toBe('http://example.com/img.png');
+  test('images render correctly when expanded', () => {
+    window.chatHistory = [{ msg: '![alt](http://example.com/img.png)' }];
+    const { getByRole, container } = render(<ChatBox />);
+    fireEvent.click(getByRole('button'));
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img.src).toBe('http://example.com/img.png');
+  });
 });


### PR DESCRIPTION
## Summary
- implement new ChatBox with expand/collapse button
- load messages from `window.chatHistory`
- adjust tests to use the updated component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849c16a49d483269148dcadf2ac3dc9