### PR TITLE
Fix mobile chat input visibility

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -485,6 +485,9 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   inputBox.style.alignItems = 'center';
   inputBox.style.overflow = 'hidden';
   inputBox.style.padding = '0 4px';
+  inputBox.style.position = 'sticky';
+  inputBox.style.bottom = '0';
+  inputBox.style.zIndex = '10';
 
   input = document.createElement('input');
   input.placeholder = 'Votre message...';


### PR DESCRIPTION
## Summary
- keep chat text input sticky at the bottom of the widget on mobile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849eee9195c83269f497e7ebe4b6338