### PR TITLE
Fix sticky input position

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -498,6 +498,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   widget.appendChild(chatLog);
 
   inputBox = document.createElement('div');
+  inputBox.classList.add('chat-input-box');
   inputBox.style.display = hasOpenedChat ? 'flex' : 'none';
   inputBox.style.background = '#fff';
   inputBox.style.borderRadius = '16px';
@@ -973,6 +974,10 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     button:focus { outline: 2px solid #009fff77 !important; }
     .msg-fadein { animation: fadeInUp 0.4s; }
     @keyframes fadeInUp { from { opacity:0; transform:translateY(12px);} to{opacity:1; transform:translateY(0);} }
+    .custom-chatbot-widget .chat-input-box {
+      position: sticky;
+      bottom: 0;
+    }
   `;
   const demoMsg = '# Exemple de markdown\n\n**Bienvenue** sur le *chatbot*.\n\n- Premier\n- Deuxième\n\n![Image](https://via.placeholder.com/150)\n\n[Visiter le site](https://example.com)';
   appendMessage(demoMsg, 'bot', true);


### PR DESCRIPTION
## Summary
- keep ChatbotWidget input area sticky via inline styles
- add CSS rule so `.chat-input-box` stays at the bottom of the widget

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc947604483269afa0390a6b7e7e3