### PR TITLE
Fix chatbot widget layout

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -249,7 +249,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   // === Widget panel principal ===
   widget = document.createElement('div');
   Object.assign(widget.style, {
-    display: 'none',
+    display: 'flex',
     flexDirection: 'column',
     width: '350px',
     maxWidth: '90vw',


### PR DESCRIPTION
## Summary
- maintain flexbox layout by showing widget as `display:flex`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f01f445ec8326bf4f3310951d4059