### PR TITLE
Fix expand/reduce transform handler

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -440,8 +440,8 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     reduceBtn.style.display = 'inline-block';
     if (widget) {
       widget.style.maxHeight = 'calc(90vh - 40px)';
-      widget.style.transform = 'translateY(-40px)';
     }
+    if (container) container.style.transform = 'translateY(-40px)';
   };
   reduceBtn.onclick = () => {
     isExpanded = false;
@@ -454,8 +454,8 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     reduceBtn.style.display = 'none';
     if (widget) {
       widget.style.maxHeight = 'calc(90vh - 40px)';
-      widget.style.transform = 'translateY(0)';
     }
+    if (container) container.style.transform = 'translateY(0)';
 
   };
 


### PR DESCRIPTION
## Summary
- update expand/reduce handlers in public/ChatbotWidget.js
- shift translation to container element instead of widget

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684f20ca399883269adce56454127d2c