### PR TITLE
Reset widget on new session

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -71,6 +71,20 @@ function createNewSession() {
   sessions.push(session);
   saveSessions();
   setCurrentSession(session.id);
+  hasOpenedChat = false;
+  localStorage.setItem('chatbotHasOpened', 'false');
+  if (chatLog) {
+    chatLog.innerHTML = '';
+    if (typeof expandBtn !== 'undefined' && expandBtn) chatLog.appendChild(expandBtn);
+    if (typeof reduceBtn !== 'undefined' && reduceBtn) chatLog.appendChild(reduceBtn);
+    if (expandBtn) expandBtn.style.display = 'inline-block';
+    if (reduceBtn) reduceBtn.style.display = 'none';
+    chatLog.style.display = 'none';
+  }
+  if (inputBox) inputBox.style.display = 'none';
+  if (vocalCtaBox) vocalCtaBox.style.display = 'none';
+  if (suggBox) suggBox.style.display = '';
+  notifyHistory();
   if (typeof renderSessions === 'function') renderSessions();
 }
 


### PR DESCRIPTION
## Summary
- reset chat state when creating new session
- keep suggestion box visible when a new chat starts
- notify listeners of cleared history

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f576bf1208326bafa02a42de77f55