### PR TITLE
Add optional session limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,21 @@ Tailwind when working locally:
 Create React App processes Tailwind automatically during `npm start` and
 `npm run build`.
 
+## Session Storage Limits
+
+`ChatbotWidget.js` stores session history in the browser's local storage. To prevent local storage from growing indefinitely you can provide optional limits via script attributes:
+
+```html
+<script
+  src="/ChatbotWidget.js"
+  data-client-id="my-client"
+  data-max-sessions="10"
+  data-max-history="50">
+</script>
+```
+
+* `data-max-sessions` – maximum number of sessions kept. Older sessions are discarded when the limit is exceeded.
+* `data-max-history` – maximum number of messages stored per session. Only the most recent messages are retained.
+
+If not specified, all sessions and messages are preserved.
+

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -14,6 +14,7 @@ const CURRENT_KEY = 'chatbotCurrentSession';
 let sessions = [];
 let currentSessionId;
 let renderHistory = () => {};
+let widgetConfig = {};
 
 function loadScript(src) {
   return new Promise(res => {
@@ -51,6 +52,21 @@ function loadSessions() {
 }
 
 function saveSessions() {
+  const cfg = widgetConfig || {};
+  if (cfg.maxHistory && Number.isFinite(cfg.maxHistory)) {
+    sessions.forEach(s => {
+      if (s.history.length > cfg.maxHistory) {
+        s.history = s.history.slice(-cfg.maxHistory);
+      }
+    });
+  }
+  if (cfg.maxSessions && Number.isFinite(cfg.maxSessions) && sessions.length > cfg.maxSessions) {
+    sessions = sessions.slice(-cfg.maxSessions);
+    if (!sessions.some(s => s.id === currentSessionId)) {
+      currentSessionId = sessions[sessions.length - 1]?.id;
+      if (currentSessionId) localStorage.setItem(CURRENT_KEY, currentSessionId);
+    }
+  }
   localStorage.setItem(SESSION_KEY, JSON.stringify(sessions));
 }
 
@@ -94,6 +110,8 @@ async function loadAndInitChatbot(speechSupported) {
   const scriptTag = document.currentScript || document.querySelector('script[data-client-id]');
   const clientId = scriptTag?.getAttribute('data-client-id') || "novacorp";
   const backendUrl = scriptTag?.getAttribute('data-backend-url') || "https://chatbot-vocal-backend.onrender.com";
+  const maxSessions = parseInt(scriptTag?.getAttribute('data-max-sessions'), 10);
+  const maxHistory = parseInt(scriptTag?.getAttribute('data-max-history') || scriptTag?.getAttribute('data-max-messages'), 10);
   let config = {
     color: "#0078d4",
     logo: null,
@@ -102,7 +120,9 @@ async function loadAndInitChatbot(speechSupported) {
       "Quels sont vos services ?",
       "J’aimerais en savoir plus sur vos tarifs"
     ],
-    rgpdLink: "/politique-confidentialite.html"
+    rgpdLink: "/politique-confidentialite.html",
+    maxSessions: null,
+    maxHistory: null
   };
   try {
     const res = await fetch(`${backendUrl}/config/${clientId}.json`);
@@ -117,6 +137,10 @@ async function loadAndInitChatbot(speechSupported) {
   } catch (e) {
     showAlert("Erreur réseau : la configuration du chatbot n'a pas pu être chargée.");
   }
+  if (Number.isFinite(maxSessions)) config.maxSessions = maxSessions;
+  if (Number.isFinite(maxHistory)) config.maxHistory = maxHistory;
+  widgetConfig = config;
+  window.chatbotWidgetConfig = config;
   initChatbot(config, backendUrl, clientId, speechSupported);
 }
 


### PR DESCRIPTION
## Summary
- support `data-max-sessions` and `data-max-history` attributes
- trim stored sessions and history in `saveSessions`
- document storage limits in README

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f57abe0648326a44677479c57cdab