### PR TITLE
Fix closeWidget full-screen cleanup

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -185,12 +185,16 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   }
   // ----------- PATCH FERMETURE --------
   function closeWidget() {
-    if (typeof widget !== "undefined" && widget) widget.style.display = 'none';
+    if (typeof widget !== "undefined" && widget) {
+      widget.style.display = 'none';
+      widget.classList.remove('fullscreen-mode');
+    }
     if (typeof launcher !== "undefined" && launcher) launcher.style.display = 'inline-block';
     isWidgetOpen = false;
+    isExpanded = false;
+    if(expandBtn) expandBtn.style.display='inline-block';
+    if(reduceBtn) reduceBtn.style.display='none';
     if(sidebar) sidebar.style.display='none';
-
-
     if (typeof sizeToggleBtn !== "undefined" && sizeToggleBtn) sizeToggleBtn.textContent = '🗖';
     if (typeof chatLog !== "undefined" && chatLog) {
       chatLog.style.maxHeight = '160px';
@@ -201,6 +205,13 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     if (typeof inputBox !== "undefined" && inputBox) inputBox.style.display = 'none';
     if (typeof vocalCtaBox !== "undefined" && vocalCtaBox) vocalCtaBox.style.display = 'none';
     if (typeof suggBox !== "undefined" && suggBox) suggBox.style.display = '';
+    if (container) {
+      container.style.bottom = 'calc(20px + env(safe-area-inset-bottom))';
+      container.style.right = '20px';
+      container.style.top = '';
+      container.style.left = '';
+      container.style.transform = 'translateY(0)';
+    }
     if (window.innerWidth < 500) {
       document.body.style.overflow = '';
       window.scrollTo(0, 0);

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -200,10 +200,22 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
 
   
   function closeWidget() {
-    if (typeof widget !== "undefined" && widget) widget.style.display = 'none';
+    if (typeof widget !== "undefined" && widget) {
+      widget.style.display = 'none';
+      widget.classList.remove('fullscreen-mode');
+    }
     if (typeof launcher !== "undefined" && launcher) launcher.style.display = 'inline-block';
     isWidgetOpen = false;
-    if (container) container.style.transform = 'translateY(0)';
+    isExpanded = false;
+    if (typeof expandBtn !== "undefined" && expandBtn) expandBtn.style.display = 'inline-block';
+    if (typeof reduceBtn !== "undefined" && reduceBtn) reduceBtn.style.display = 'none';
+    if (container) {
+      container.style.transform = 'translateY(0)';
+      container.style.bottom = 'calc(20px + env(safe-area-inset-bottom))';
+      container.style.right = '20px';
+      container.style.top = '';
+      container.style.left = '';
+    }
     if (typeof chatLog !== "undefined" && chatLog) chatLog.style.display = 'none';
     if (typeof inputBox !== "undefined" && inputBox) inputBox.style.display = 'none';
     if (typeof vocalCtaBox !== "undefined" && vocalCtaBox) vocalCtaBox.style.display = 'none';


### PR DESCRIPTION
## Summary
- update `closeWidget` to clear fullscreen state and reset controls

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c66e427708326b0f0b5c3d3cfd154