### PR TITLE
Fix chat session reset and remove send button

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -80,6 +80,8 @@ function setCurrentSession(id) {
   if (typeof renderHistory === 'function') renderHistory();
   if (typeof renderSessions === 'function') renderSessions();
   saveSessions();
+  window.chatHistory = getCurrentSession()?.history.slice() || [];
+  window.dispatchEvent(new Event('chatHistoryUpdate'));
 }
 
 function deleteSession(id) {
@@ -619,23 +621,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
 
   inputBox.appendChild(input);
 
-  const sendBtn = document.createElement('button');
-  sendBtn.textContent = 'Envoyer';
-  Object.assign(sendBtn.style, {
-    border: 'none',
-    background: 'none',
-    fontSize: '20px',
-    color: config.color,
-    cursor: 'pointer',
-    marginLeft: '6px'
-  });
-  sendBtn.onclick = () => {
-    if (input.value.trim()) {
-      handleMessage(input.value);
-      input.value = '';
-    }
-  };
-  inputBox.appendChild(sendBtn);
+  // bouton d'envoi supprimé : envoi uniquement via la touche Entrée
   footerContainer.appendChild(inputBox);
 
   vocalCtaBox = document.createElement('div');
@@ -899,12 +885,11 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     }
     if (!chatLog) return;
     if (suggBox) suggBox.style.display = 'none';
-    appendMessage(msg, 'user');
-    renderHistory();
     const cur = getCurrentSession();
     if (cur) cur.history.push({ msg, sender: 'user', isHTML: false });
     saveSessions();
     notifyHistory();
+    renderHistory();
     showLoader();
     if (currentAudio && !currentAudio.paused) {
       currentAudio.pause();

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -80,6 +80,8 @@ function setCurrentSession(id) {
   if (typeof renderHistory === 'function') renderHistory();
   if (typeof renderSessions === 'function') renderSessions();
   saveSessions();
+  window.chatHistory = getCurrentSession()?.history.slice() || [];
+  window.dispatchEvent(new Event('chatHistoryUpdate'));
 }
 
 function deleteSession(id) {
@@ -631,23 +633,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
 
   inputBox.appendChild(input);
 
-  const sendBtn = document.createElement('button');
-  sendBtn.textContent = 'Envoyer';
-  Object.assign(sendBtn.style, {
-    border: 'none',
-    background: 'none',
-    fontSize: '20px',
-    color: config.color,
-    cursor: 'pointer',
-    marginLeft: '6px'
-  });
-  sendBtn.onclick = () => {
-    if (input.value.trim()) {
-      handleMessage(input.value);
-      input.value = '';
-    }
-  };
-  inputBox.appendChild(sendBtn);
+  // bouton d'envoi supprimé : envoi uniquement via la touche Entrée
   footerContainer.appendChild(inputBox);
 
   vocalCtaBox = document.createElement('div');
@@ -911,12 +897,11 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     }
     if (!chatLog) return;
     if (suggBox) suggBox.style.display = 'none';
-    appendMessage(msg, 'user');
-    renderHistory();
     const cur = getCurrentSession();
     if (cur) cur.history.push({ msg, sender: 'user', isHTML: false });
     saveSessions();
     notifyHistory();
+    renderHistory();
     showLoader();
     if (currentAudio && !currentAudio.paused) {
       currentAudio.pause();


### PR DESCRIPTION
## Summary
- push user messages into history before rendering so suggestions work
- remove the redundant send button and rely on Enter key
- propagate chat history when switching sessions

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7106d19c832682737a22b6b2a982