### PR TITLE
Update viewport units to svh

### DIFF
--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -362,7 +362,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
   sidebar = document.createElement('div');
   sidebar.className = 'sidebar';
   sidebar.style.width = '180px';
-  sidebar.style.maxHeight = 'calc(90vh - 40px)';
+  sidebar.style.maxHeight = 'calc(90svh - 40px)';
   sidebar.style.overflowY = 'auto';
   sidebar.style.background = '#fff';
   sidebar.style.borderRadius = '12px';
@@ -444,7 +444,7 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
     padding: '20px',
     fontFamily: 'system-ui, "Segoe UI", sans-serif',
     height: 'auto',
-    maxHeight: 'calc(90vh - 40px)',
+    maxHeight: 'calc(90svh - 40px)',
     overflow: 'hidden'
   });
   widget.classList.add('custom-chatbot-widget');

--- a/src/ChatBox.js
+++ b/src/ChatBox.js
@@ -17,7 +17,7 @@ export default function ChatBox() {
     <div className="flex flex-col w-full items-center">
       <div
         className={`relative transition-all duration-300 bg-white rounded-2xl shadow p-4 mb-2 w-full max-w-lg ${
-          expanded ? "max-h-[80vh]" : "max-h-72"
+          expanded ? "max-h-[80svh]" : "max-h-72"
         } overflow-y-auto`}
         style={{ minHeight: 120 }}
       >

--- a/src/__tests__/ChatBox.test.js
+++ b/src/__tests__/ChatBox.test.js
@@ -27,7 +27,7 @@ describe('ChatBox', () => {
     const box = container.querySelector('div.relative');
     expect(box.className).toContain('max-h-72');
     fireEvent.click(btn);
-    expect(box.className).toContain('max-h-[80vh]');
+    expect(box.className).toContain('max-h-[80svh]');
     fireEvent.click(btn);
     expect(box.className).toContain('max-h-72');
   });


### PR DESCRIPTION
## Summary
- use `max-h-[80svh]` when expanding `ChatBox`
- adjust height calculations in `ChatbotWidget.js` to `90svh`
- update tests for new svh values

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c791eb09c832689237584bd53f2d4