### PR TITLE
Reset audio on session change

### DIFF
--- a/build/ChatbotWidget.js
+++ b/build/ChatbotWidget.js
@@ -75,6 +75,7 @@ function getCurrentSession() {
 }
 
 function setCurrentSession(id) {
+  if (window.chatbotResetSession) window.chatbotResetSession();
   currentSessionId = id;
   localStorage.setItem(CURRENT_KEY, id);
   if (typeof renderHistory === 'function') renderHistory();
@@ -114,6 +115,7 @@ function createNewSession() {
   sessions.push(session);
   saveSessions();
   setCurrentSession(session.id);
+  if (window.chatbotResetSession) window.chatbotResetSession();
   exitFullscreen();
   renderHistory();
 }
@@ -711,6 +713,16 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
       if (vocalCtaBox) vocalCtaBox.style.display = 'flex';
     }
   }
+  window.chatbotResetSession = function() {
+    if (recognition) recognition.abort();
+    if (currentAudio && !currentAudio.paused) {
+      currentAudio.pause();
+      currentAudio.currentTime = 0;
+    }
+    currentAudio = null;
+    isTextMode = true;
+    updateModeUI();
+  };
   if (speechSupported) footerNav.appendChild(vocalTab);
   footerNav.appendChild(textTab);
   footerContainer.appendChild(footerNav);

--- a/public/ChatbotWidget.js
+++ b/public/ChatbotWidget.js
@@ -75,6 +75,7 @@ function getCurrentSession() {
 }
 
 function setCurrentSession(id) {
+  if (window.chatbotResetSession) window.chatbotResetSession();
   currentSessionId = id;
   localStorage.setItem(CURRENT_KEY, id);
   if (typeof renderHistory === 'function') renderHistory();
@@ -114,6 +115,7 @@ function createNewSession() {
   sessions.push(session);
   saveSessions();
   setCurrentSession(session.id);
+  if (window.chatbotResetSession) window.chatbotResetSession();
   exitFullscreen();
   renderHistory();
 }
@@ -723,6 +725,16 @@ function initChatbot(config, backendUrl, clientId, speechSupported) {
       if (vocalCtaBox) vocalCtaBox.style.display = 'flex';
     }
   }
+  window.chatbotResetSession = function() {
+    if (recognition) recognition.abort();
+    if (currentAudio && !currentAudio.paused) {
+      currentAudio.pause();
+      currentAudio.currentTime = 0;
+    }
+    currentAudio = null;
+    isTextMode = true;
+    updateModeUI();
+  };
   if (speechSupported) footerNav.appendChild(vocalTab);
   footerNav.appendChild(textTab);
   footerContainer.appendChild(footerNav);


### PR DESCRIPTION
## Summary
- stop audio/recognition and reset mode whenever changing chat sessions
- expose `chatbotResetSession` helper to control audio and recognition

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c791d3d1c83268fa81fcfda241f7c